### PR TITLE
feat: add windows compatibility for process management and path handling

### DIFF
--- a/cmd/shadowfax/main.go
+++ b/cmd/shadowfax/main.go
@@ -2,21 +2,21 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/joho/godotenv"
 
 	"github.com/mbvlabs/shadowfax/internal/config"
+	"github.com/mbvlabs/shadowfax/internal/platform"
 	"github.com/mbvlabs/shadowfax/internal/proxy"
 	"github.com/mbvlabs/shadowfax/internal/reload"
 	"github.com/mbvlabs/shadowfax/internal/server"
@@ -70,7 +70,7 @@ func main() {
 	templChange := make(chan watcher.TemplChange, 64)
 
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(sigChan, platform.TerminationSignals()...)
 
 	var wg sync.WaitGroup
 	errChan := make(chan error, 5)
@@ -193,7 +193,7 @@ func main() {
 				case watcher.TemplChangeNeedsBrowserReload:
 					if useTailwind {
 						fmt.Println("[shadowfax] Template changed, triggering CSS rebuild")
-						if err := touchFile("./css/base.css"); err != nil {
+						if err := touchFile(filepath.Join("css", "base.css")); err != nil {
 							fmt.Printf("[shadowfax] Warning: could not touch CSS file: %v\n", err)
 							// Fall back to broadcasting directly
 							broadcaster.Broadcast()
@@ -206,7 +206,7 @@ func main() {
 					fmt.Println("[shadowfax] Template Go code changed, rebuilding")
 					if useTailwind {
 						rebuildInProgress.Store(true)
-						if err := touchFile("./css/base.css"); err != nil && verbose {
+						if err := touchFile(filepath.Join("css", "base.css")); err != nil && verbose {
 							fmt.Printf("[shadowfax] Warning: could not touch CSS file: %v\n", err)
 						}
 					}
@@ -273,7 +273,7 @@ func cleanup() {
 	// Ask tracked child processes to stop first.
 	for _, cmd := range processes {
 		if cmd != nil && cmd.Process != nil {
-			_ = cmd.Process.Signal(syscall.SIGTERM)
+			_ = platform.SignalStop(cmd.Process)
 		}
 	}
 
@@ -283,7 +283,7 @@ func cleanup() {
 		if cmd == nil || cmd.Process == nil {
 			continue
 		}
-		if processAlive(cmd.Process) {
+		if platform.IsProcessAlive(cmd.Process) {
 			_ = cmd.Process.Kill()
 		}
 	}
@@ -304,21 +304,12 @@ func compactRunningProcessesLocked() {
 		if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
 			continue
 		}
-		if !processAlive(cmd.Process) {
+		if !platform.IsProcessAlive(cmd.Process) {
 			continue
 		}
 		compacted = append(compacted, cmd)
 	}
 	runningProcesses = compacted
-}
-
-func processAlive(process *os.Process) bool {
-	if process == nil {
-		return false
-	}
-
-	err := process.Signal(syscall.Signal(0))
-	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
 func runProxyServer(

--- a/internal/platform/path.go
+++ b/internal/platform/path.go
@@ -1,0 +1,15 @@
+package platform
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+// BinaryPath returns the correct path for a binary based on GOOS.
+// It appends .exe on Windows and ensures path separators are correct.
+func BinaryPath(path string) string {
+	if runtime.GOOS == "windows" {
+		path += ".exe"
+	}
+	return filepath.FromSlash(path)
+}

--- a/internal/platform/process.go
+++ b/internal/platform/process.go
@@ -1,0 +1,21 @@
+package platform
+
+import "os"
+
+// SignalStop attempts to gracefully stop a process.
+// On Unix, it sends SIGTERM. On Windows, it sends a kill signal
+// as graceful shutdown via signals is not directly supported for
+// general processes.
+func SignalStop(process *os.Process) error {
+	return signalStop(process)
+}
+
+// IsProcessAlive checks if a process is still running.
+func IsProcessAlive(process *os.Process) bool {
+	return isProcessAlive(process)
+}
+
+// TerminationSignals returns the signals that should trigger a graceful shutdown.
+func TerminationSignals() []os.Signal {
+	return terminationSignals()
+}

--- a/internal/platform/process_unix.go
+++ b/internal/platform/process_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package platform
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func signalStop(process *os.Process) error {
+	if process == nil {
+		return nil
+	}
+	return process.Signal(syscall.SIGTERM)
+}
+
+func isProcessAlive(process *os.Process) bool {
+	if process == nil {
+		return false
+	}
+
+	err := process.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+// terminationSignals returns the signals that should trigger a graceful shutdown.
+func terminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/internal/platform/process_windows.go
+++ b/internal/platform/process_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package platform
+
+import (
+	"os"
+	"syscall"
+)
+
+func signalStop(process *os.Process) error {
+	if process == nil {
+		return nil
+	}
+	// On Windows, signals are not supported.
+	// Graceful shutdown is hard for general processes, so we kill.
+	return process.Kill()
+}
+
+func isProcessAlive(process *os.Process) bool {
+	if process == nil {
+		return false
+	}
+
+	h, err := syscall.OpenProcess(syscall.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(process.Pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(h)
+
+	var exitCode uint32
+	err = syscall.GetExitCodeProcess(h, &exitCode)
+	if err != nil {
+		return false
+	}
+
+	return exitCode == 259 // STILL_ACTIVE
+}
+
+// terminationSignals returns the signals that should trigger a graceful shutdown.
+func terminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 
+	"github.com/mbvlabs/shadowfax/internal/platform"
 	"github.com/mbvlabs/shadowfax/internal/reload"
 )
 
@@ -35,9 +36,10 @@ type Config struct {
 
 func NewAppServer(cfg Config) *AppServer {
 	wd, _ := os.Getwd()
+	binPath := platform.BinaryPath("tmp/bin/main")
 	return &AppServer{
-		buildCmd:              "go build -o tmp/bin/main cmd/app/main.go",
-		binPath:               wd + "/tmp/bin/main",
+		buildCmd:              fmt.Sprintf("go build -o %s %s", binPath, filepath.Join("cmd", "app", "main.go")),
+		binPath:               filepath.Join(wd, binPath),
 		appPort:               cfg.AppPort,
 		broadcaster:           cfg.Broadcaster,
 		addProcess:            cfg.AddProcess,
@@ -73,7 +75,8 @@ func (s *AppServer) Run(ctx context.Context, rebuildChan <-chan struct{}) error 
 func (s *AppServer) rebuild(ctx context.Context) error {
 	fmt.Println("[shadowfax] Building...")
 
-	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", "tmp/bin/main", "cmd/app/main.go")
+	binPath := platform.BinaryPath("tmp/bin/main")
+	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", binPath, filepath.Join("cmd", "app", "main.go"))
 	buildCmd.Stdout = os.Stdout
 	buildCmd.Stderr = os.Stderr
 
@@ -103,7 +106,7 @@ func (s *AppServer) rebuild(ctx context.Context) error {
 func (s *AppServer) stop() {
 	s.cancelHealthMonitor()
 	if s.cmd != nil && s.cmd.Process != nil {
-		s.cmd.Process.Signal(syscall.SIGTERM)
+		platform.SignalStop(s.cmd.Process)
 		done := make(chan error, 1)
 		go func() { done <- s.cmd.Wait() }()
 

--- a/internal/watcher/tailwind.go
+++ b/internal/watcher/tailwind.go
@@ -8,9 +8,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/mbvlabs/shadowfax/internal/platform"
 )
 
 type TailwindConfig struct {
@@ -26,7 +29,8 @@ func RunTailwindWatcher(ctx context.Context, cssRebuilt chan<- struct{}, cfg Tai
 		return err
 	}
 
-	cmd := exec.CommandContext(ctx, wd+"/bin/tailwindcli",
+	binPath := filepath.Join(wd, platform.BinaryPath("bin/tailwindcli"))
+	cmd := exec.CommandContext(ctx, binPath,
 		"-i", "./css/base.css",
 		"-o", "./assets/css/style.css",
 		"--watch=always",

--- a/internal/watcher/tailwind_test.go
+++ b/internal/watcher/tailwind_test.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/mbvlabs/shadowfax/internal/platform"
 )
 
 func TestIsTailwindRebuildDoneLine(t *testing.T) {
@@ -132,7 +134,7 @@ func createTailwindScript(t *testing.T, root, content string) {
 		t.Fatal(err)
 	}
 
-	path := filepath.Join(binDir, "tailwindcli")
+	path := filepath.Join(binDir, platform.BinaryPath("tailwindcli"))
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/watcher/templ.go
+++ b/internal/watcher/templ.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
+
+	"github.com/mbvlabs/shadowfax/internal/platform"
 )
 
 type TemplChange int8
@@ -41,8 +44,9 @@ func RunTemplWatcher(ctx context.Context, templChange chan<- TemplChange, cfg Te
 		return err
 	}
 
+	binPath := filepath.Join(wd, platform.BinaryPath("bin/templ"))
 	cmd := exec.Command(
-		wd+"/bin/templ", "generate",
+		binPath, "generate",
 		"--watch",
 		"--log-level", "debug",
 		// Only watch .templ files - the Go watcher handles .go files
@@ -121,7 +125,7 @@ func stopTemplProcess(cmd *exec.Cmd, done <-chan error) {
 		return
 	}
 
-	_ = cmd.Process.Signal(os.Interrupt)
+	_ = platform.SignalStop(cmd.Process)
 
 	timer := time.NewTimer(templShutdownTimeout)
 	defer timer.Stop()

--- a/internal/watcher/templ_test.go
+++ b/internal/watcher/templ_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/mbvlabs/shadowfax/internal/platform"
 )
 
 func TestRunTemplWatcherCancelUsesKillFallback(t *testing.T) {
@@ -88,7 +90,7 @@ func createTemplScript(t *testing.T, root, content string) {
 		t.Fatal(err)
 	}
 
-	path := filepath.Join(binDir, "templ")
+	path := filepath.Join(binDir, platform.BinaryPath("templ"))
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Created 'internal/platform' to abstract process signals and health checks.
- Replaced hardcoded binary paths and Unix signals with cross-platform alternatives.
- Used 'filepath' utilities for all file path operations.
- Updated watchers and tests to support '.exe' extension on Windows.

addresses windows support feature issue [#22](https://github.com/mbvlabs/shadowfax/issues/22)