### PR TITLE
feat: verify four-platform release assets

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,0 +1,11 @@
+# Publishing a release
+
+Release publication is intentionally manual and must run through the Release workflow.
+
+1. Create and push a version tag such as `v0.9.0`.
+2. Open **Actions**, select **Release**, and choose **Run workflow**.
+3. Enter the existing tag and start the workflow.
+
+The workflow checks out the exact tag, builds all four targets with Go 1.26.5, creates `checksums.txt`, and verifies the Linux arm64 binary on a native arm64 runner. It uploads the files to a draft release, downloads and verifies the uploaded bytes, and only then publishes the release.
+
+Do not create or publish the GitHub release first. The workflow refuses to modify an existing release or replace any asset.

--- a/.github/release-targets.txt
+++ b/.github/release-targets.txt
@@ -1,0 +1,4 @@
+linux amd64 shadowfax-linux-amd64
+linux arm64 shadowfax-linux-arm64
+darwin amd64 shadowfax-darwin-amd64
+darwin arm64 shadowfax-darwin-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,58 +1,173 @@
 name: Release
+run-name: Release ${{ inputs.tag }}
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing version tag to publish, for example v0.9.0
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  release:
+    runs-on: ubuntu-24.04-arm
+    env:
+      TAG: ${{ inputs.tag }}
+      GH_TOKEN: ${{ github.token }}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag }}
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.25.3'
+      - name: Validate tag and release state
+        shell: bash
+        run: |
+          set -euo pipefail
 
-    - name: Get version
-      id: version
-      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: $TAG" >&2
+            exit 1
+          fi
 
-    - name: Build binaries
-      run: |
-        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-w -s -X main.Version=${{ steps.version.outputs.VERSION }}" -o shadowfax-linux-amd64 ./cmd/shadowfax
-        CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-w -s -X main.Version=${{ steps.version.outputs.VERSION }}" -o shadowfax-darwin-amd64 ./cmd/shadowfax
-        CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-w -s -X main.Version=${{ steps.version.outputs.VERSION }}" -o shadowfax-darwin-arm64 ./cmd/shadowfax
+          tag_commit="$(git rev-list -n 1 "$TAG")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Checked out $head_commit instead of tag commit $tag_commit" >&2
+            exit 1
+          fi
 
-    - name: Upload linux asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./shadowfax-linux-amd64
-        asset_name: shadowfax-linux-amd64
-        asset_content_type: application/octet-stream
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists. Existing releases and assets are never modified." >&2
+            exit 1
+          fi
 
-    - name: Upload macOS AMD64 asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./shadowfax-darwin-amd64
-        asset_name: shadowfax-darwin-amd64
-        asset_content_type: application/octet-stream
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.5'
+          cache: true
 
-    - name: Upload macOS ARM64 asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./shadowfax-darwin-arm64
-        asset_name: shadowfax-darwin-arm64
-        asset_content_type: application/octet-stream
+      - name: Build release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+
+          while read -r goos goarch asset; do
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+              go build \
+                -ldflags "-w -s -X main.Version=$TAG" \
+                -o "dist/$asset" \
+                ./cmd/shadowfax
+          done < .github/release-targets.txt
+
+      - name: Validate local release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t required_assets < <(awk '{print $3}' .github/release-targets.txt)
+
+          if [[ "${#required_assets[@]}" -ne 4 ]]; then
+            echo "Expected four release targets, found ${#required_assets[@]}" >&2
+            exit 1
+          fi
+
+          cd dist
+          for asset in "${required_assets[@]}"; do
+            if [[ ! -f "$asset" || ! -x "$asset" ]]; then
+              echo "Missing or non-executable release asset: $asset" >&2
+              exit 1
+            fi
+            go version -m "$asset" >/dev/null
+          done
+
+          sha256sum "${required_assets[@]}" > checksums.txt
+          sha256sum --check --strict checksums.txt
+
+          if [[ "$(wc -l < checksums.txt)" -ne 4 ]]; then
+            echo "checksums.txt must contain exactly four entries" >&2
+            exit 1
+          fi
+
+          for asset in "${required_assets[@]}"; do
+            if ! grep -Eq "^[0-9a-f]{64}  ${asset}$" checksums.txt; then
+              echo "Missing or invalid checksum entry for $asset" >&2
+              exit 1
+            fi
+          done
+
+          version_output="$(./shadowfax-linux-arm64 --version)"
+          if [[ "$version_output" != "shadowfax version $TAG" ]]; then
+            echo "Unexpected Linux arm64 version output: $version_output" >&2
+            exit 1
+          fi
+
+      - name: Create draft release
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t required_assets < <(awk '{print "dist/" $3}' .github/release-targets.txt)
+          required_assets+=(dist/checksums.txt)
+
+          gh release create "$TAG" \
+            "${required_assets[@]}" \
+            --draft \
+            --generate-notes \
+            --title "$TAG" \
+            --verify-tag
+
+      - name: Verify uploaded release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t required_assets < <(awk '{print $3}' .github/release-targets.txt)
+          mkdir uploaded
+          gh release download "$TAG" --dir uploaded
+
+          cd uploaded
+          for asset in "${required_assets[@]}"; do
+            if [[ ! -f "$asset" ]]; then
+              echo "Draft release is missing $asset" >&2
+              exit 1
+            fi
+          done
+
+          if [[ ! -f checksums.txt ]]; then
+            echo "Draft release is missing checksums.txt" >&2
+            exit 1
+          fi
+
+          sha256sum --check --strict checksums.txt
+          if ! cmp checksums.txt ../dist/checksums.txt; then
+            echo "Uploaded checksums.txt differs from the validated local file" >&2
+            exit 1
+          fi
+
+          for asset in "${required_assets[@]}"; do
+            if ! grep -Eq "^[0-9a-f]{64}  ${asset}$" checksums.txt; then
+              echo "Uploaded checksums.txt has no valid entry for $asset" >&2
+              exit 1
+            fi
+          done
+
+          chmod +x shadowfax-linux-arm64
+          version_output="$(./shadowfax-linux-arm64 --version)"
+          if [[ "$version_output" != "shadowfax version $TAG" ]]; then
+            echo "Unexpected uploaded Linux arm64 version output: $version_output" >&2
+            exit 1
+          fi
+
+      - name: Publish release
+        shell: bash
+        run: gh release edit "$TAG" --draft=false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.3'
+          go-version: '1.26.5'
 
       - name: Run tests
         run: go test ./...

--- a/internal/releaseconfig/release_test.go
+++ b/internal/releaseconfig/release_test.go
@@ -1,0 +1,78 @@
+package releaseconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestReleaseTargetMatrix(t *testing.T) {
+	root := repositoryRoot(t)
+	targets := readFile(t, filepath.Join(root, ".github", "release-targets.txt"))
+
+	want := strings.Join([]string{
+		"linux amd64 shadowfax-linux-amd64",
+		"linux arm64 shadowfax-linux-arm64",
+		"darwin amd64 shadowfax-darwin-amd64",
+		"darwin arm64 shadowfax-darwin-arm64",
+		"",
+	}, "\n")
+
+	if targets != want {
+		t.Fatalf("unexpected release target matrix\nwant:\n%s\ngot:\n%s", want, targets)
+	}
+}
+
+func TestReleasePublicationIsGatedByVerification(t *testing.T) {
+	root := repositoryRoot(t)
+	workflow := readFile(t, filepath.Join(root, ".github", "workflows", "release.yml"))
+
+	required := []string{
+		"workflow_dispatch:",
+		"runs-on: ubuntu-24.04-arm",
+		"go-version: '1.26.5'",
+		"done < .github/release-targets.txt",
+		"CGO_ENABLED=0 GOOS=\"$goos\" GOARCH=\"$goarch\"",
+		"sha256sum --check --strict checksums.txt",
+		"gh release create \"$TAG\"",
+		"--draft",
+		"gh release download \"$TAG\" --dir uploaded",
+		"gh release edit \"$TAG\" --draft=false",
+	}
+	for _, value := range required {
+		if !strings.Contains(workflow, value) {
+			t.Errorf("release workflow is missing %q", value)
+		}
+	}
+
+	localValidation := strings.Index(workflow, "- name: Validate local release assets")
+	draftCreation := strings.Index(workflow, "- name: Create draft release")
+	remoteValidation := strings.Index(workflow, "- name: Verify uploaded release assets")
+	publication := strings.Index(workflow, "- name: Publish release")
+	if localValidation < 0 || draftCreation < 0 || remoteValidation < 0 || publication < 0 {
+		t.Fatal("release workflow is missing a required publication stage")
+	}
+	if !(localValidation < draftCreation && draftCreation < remoteValidation && remoteValidation < publication) {
+		t.Fatal("release publication must occur after local and uploaded asset verification")
+	}
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate release configuration test")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(contents)
+}


### PR DESCRIPTION
## Summary

- replace the post-publication release hook with a manually dispatched, pre-publication gate
- build Linux and macOS binaries for amd64 and arm64 with Go 1.26.5
- generate and validate `checksums.txt` before publication
- verify the exact uploaded Linux arm64 bytes on a native arm64 runner
- add focused regression coverage for the required target matrix and publication ordering
- document the manual release process

## Root cause

The previous workflow started only after a GitHub release was already public and omitted the Linux arm64 build. It could not prevent an incomplete release.

## Historical releases

The missing Linux arm64 binaries and four-platform checksum files were added to v0.8.0 and v0.8.3 without replacing any existing assets.

## Validation

- `go test ./...` with Go 1.26.5
- both historical release URLs return HTTP 200
- freshly downloaded assets pass all four checksum entries
- v0.8.0 arm64 binary prints `shadowfax version v0.8.0`
- v0.8.3 arm64 binary prints `shadowfax version v0.8.3`
